### PR TITLE
Fix bug in the command mancourses

### DIFF
--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -33,7 +33,7 @@ defmodule Listerine.Channels do
   end
 
   @doc """
-  Generates array with all available courses
+  Generates an array with embed fields that contain all available courses.
   """
   def generate_courses_embed_fields() do
     possible_embed_fiels =
@@ -51,7 +51,7 @@ defmodule Listerine.Channels do
     }
   end
 
-  # Generates a string with all the courses in a year separated by a newline
+  # Generates a string with all the courses in a year separated by a newline.
   defp get_courses_year(year) do
     courses_year_arr = Map.keys(Map.get(get_courses(), year))
     Enum.join(courses_year_arr, "\n")

--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -33,21 +33,27 @@ defmodule Listerine.Channels do
   end
 
   @doc """
-  Generates a Formated field to use in embed with all courses in the given year.
+  Generates array with all available courses
   """
-  def generate_courses_embed_field(year) do
+  def generate_courses_embed_fields() do
+    possible_embed_fiels =
+      for(year <- Map.keys(get_courses()), do: generate_courses_embed_field(year))
+
+    Enum.filter(possible_embed_fiels, fn x -> Map.get(x, :value) != "" end)
+  end
+
+  # Generates a Formated field to use in embed with all courses in the given year.
+  defp generate_courses_embed_field(year) do
     %{
-      name: Integer.to_string(year) <> "º ano",
+      name: year <> "º ano",
       value: get_courses_year(year),
       inline: true
     }
   end
 
-  @doc """
-  Generates a string with all the courses in a year separated by a newline
-  """
+  # Generates a string with all the courses in a year separated by a newline
   defp get_courses_year(year) do
-    courses_year_arr = Map.keys(Map.get(get_courses(), Integer.to_string(year)))
+    courses_year_arr = Map.keys(Map.get(get_courses(), year))
     Enum.join(courses_year_arr, "\n")
   end
 

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -56,7 +56,7 @@ defmodule Listerine.Commands do
       },
       description: "`$study CADEIRA` junta-te às salas das cadeiras
          `$study 1ano` junta-te a todas as cadeiras de um ano",
-      fields: for(year <- 1..3, do: Listerine.Channels.generate_courses_embed_field(year))
+      fields: Listerine.Channels.generate_courses_embed_fields()
     }
 
     Message.reply(message, embed: embed)


### PR DESCRIPTION
Previously if one year didn't have any courses the bot wouldn't send a message.
(Due to the fact that a field in the embed contained an empty string)
Now that bug is fixed
When a year doesn't have any courses it will not show in the embed
![sem tituloghnghj](https://user-images.githubusercontent.com/36403066/44880868-9f7ab300-aca5-11e8-8cc2-e1a56c54cf45.png)
![sem tituloghn](https://user-images.githubusercontent.com/36403066/44880871-a1447680-aca5-11e8-94d2-aaa88e3ad606.png)
