### PR TITLE
Refactor

### DIFF
--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -176,63 +176,57 @@ defmodule Listerine.Channels do
     |> prepend.(remove_course_channels(others))
   end
 
-  def add_role(_message, []) do
-    {:ok, []}
-  end
+  @doc """
+  Adds the roles passed in the `courses` list the the author of the `message`.
 
-  def add_role(message, [name | tail]) do
+  Returns a list of added roles
+  """
+  def add_role(message, courses) do
     guild = message.channel.guild_id
     member = Guild.get_member(guild, message.author.id)
-    roles = get_courses()
 
-    roles =
-      Map.merge(roles["1"], roles["2"])
-      |> Map.merge(roles["3"])
+    case get_courses() do
+      nil ->
+        nil
 
-    modified =
-      if roles[name] != nil do
-        case Member.add_role(member, roles[name]["role"]) do
-          :ok ->
-            [name | elem(add_role(message, tail), 1)]
+      roles ->
+        roles = Enum.reduce(Map.keys(roles), %{}, fn x, acc -> Map.merge(acc, roles[x]) end)
 
-          _ ->
-            elem(add_role(message, tail), 1)
-        end
-      else
-        Message.reply(message, "Role #{name} does not exist")
-        elem(add_role(message, tail), 1)
-      end
-
-    {:ok, modified}
+        Enum.filter(courses, fn x -> x in Map.keys(roles) end)
+        |> Enum.map(fn x ->
+          case Member.add_role(member, roles[x]["role"]) do
+            :ok -> x
+            _ -> "delet_this"
+          end
+        end)
+        |> Enum.filter(fn x -> x != "delet_this" end)
+    end
   end
 
-  def rm_role(_message, []) do
-    {:ok, []}
-  end
+  @doc """
+  Removes the roles passed in the `courses` list the the author of the `message`.
 
-  def rm_role(message, [name | tail]) do
+  Returns a list of removed roles
+  """
+  def rm_role(message, courses) do
     guild = message.channel.guild_id
     member = Guild.get_member(guild, message.author.id)
-    roles = get_courses()
 
-    roles =
-      Map.merge(roles["1"], roles["2"])
-      |> Map.merge(roles["3"])
+    case get_courses() do
+      nil ->
+        nil
 
-    modified =
-      if roles[name] != nil do
-        case Member.remove_role(member, roles[name]["role"]) do
-          :ok ->
-            [name | elem(rm_role(message, tail), 1)]
+      roles ->
+        roles = Enum.reduce(Map.keys(roles), %{}, fn x, acc -> Map.merge(acc, roles[x]) end)
 
-          _ ->
-            elem(rm_role(message, tail), 1)
-        end
-      else
-        Message.reply(message, "Role #{name} does not exist")
-        elem(rm_role(message, tail), 1)
-      end
-
-    {:ok, modified}
+        Enum.filter(courses, fn x -> x in Map.keys(roles) end)
+        |> Enum.map(fn x ->
+          case Member.remove_role(member, roles[x]["role"]) do
+            :ok -> x
+            _ -> "delet_this"
+          end
+        end)
+        |> Enum.filter(fn x -> x != "delet_this" end)
+    end
   end
 end

--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -193,13 +193,12 @@ defmodule Listerine.Channels do
         roles = Enum.reduce(Map.keys(roles), %{}, fn x, acc -> Map.merge(acc, roles[x]) end)
 
         Enum.filter(courses, fn x -> x in Map.keys(roles) end)
-        |> Enum.map(fn x ->
+        |> Enum.reduce([], fn x, acc ->
           case Member.add_role(member, roles[x]["role"]) do
-            :ok -> x
-            _ -> "delet_this"
+            :ok -> [x | acc]
+            _ -> acc
           end
         end)
-        |> Enum.filter(fn x -> x != "delet_this" end)
     end
   end
 
@@ -220,13 +219,12 @@ defmodule Listerine.Channels do
         roles = Enum.reduce(Map.keys(roles), %{}, fn x, acc -> Map.merge(acc, roles[x]) end)
 
         Enum.filter(courses, fn x -> x in Map.keys(roles) end)
-        |> Enum.map(fn x ->
+        |> Enum.reduce([], fn x, acc ->
           case Member.remove_role(member, roles[x]["role"]) do
-            :ok -> x
-            _ -> "delet_this"
+            :ok -> [x | acc]
+            _ -> acc
           end
         end)
-        |> Enum.filter(fn x -> x != "delet_this" end)
     end
   end
 end

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -9,57 +9,26 @@ defmodule Listerine.Commands do
   end
 
   command study(roles) do
-    case roles do
-      [] ->
-        Message.reply(message, "Usage: `study [course, ...]`")
+    role_list = Listerine.Helpers.upcase_words(roles)
 
-      _ ->
-        role_list =
-          String.upcase(roles)
-          |> String.split(" ")
-
-        a = elem(Listerine.Channels.add_role(message, role_list), 1)
-
-        case a do
-          [] ->
-            Message.reply(message, "No roles were added")
-
-          _ ->
-            Message.reply(message, "Studying: #{Listerine.Helpers.unwords(a)}")
-        end
+    case Listerine.Channels.add_role(message, role_list) do
+      [] -> Message.reply(message, "No roles were added")
+      cl -> Message.reply(message, "Studying: #{Listerine.Helpers.unwords(cl)}")
     end
   end
 
   command unstudy(roles) do
-    case roles do
-      [] ->
-        Message.reply(message, "Usage: `unstudy [course, ..]`")
+    role_list = Listerine.Helpers.upcase_words(roles)
 
-      _ ->
-        role_list =
-          String.upcase(roles)
-          |> String.split(" ")
-
-        a = elem(Listerine.Channels.rm_role(message, role_list), 1)
-
-        case a do
-          [] ->
-            Message.reply(message, "No roles were removed")
-
-          _ ->
-            Message.reply(message, "Stoped studiyng #{Listerine.Helpers.unwords(a)}")
-        end
+    case Listerine.Channels.rm_role(message, role_list) do
+      [] -> Message.reply(message, "No roles were removed")
+      cl -> Message.reply(message, "Stoped studiyng #{Listerine.Helpers.unwords(cl)}")
     end
   end
 
-  # REVIEW: See if this bug has been patched
   @permit :MANAGE_CHANNELS
   command mkcourses(text) do
-    [y | cl] =
-      text
-      |> String.split(" ")
-      |> Enum.filter(fn x -> x != "" end)
-      |> Enum.map(&String.upcase/1)
+    [y | cl] = Listerine.Helpers.upcase_words(text)
 
     cond do
       y in ["1", "2", "3"] ->
@@ -75,12 +44,9 @@ defmodule Listerine.Commands do
 
   @permit :MANAGE_CHANNELS
   command rmcourses(text) do
-    text =
-      String.split(text, " ")
-      |> Enum.filter(fn x -> x != "" end)
-      |> Enum.map(&String.upcase/1)
+    args = Listerine.Helpers.upcase_words(text)
 
-    case Listerine.Channels.remove_courses(text) do
+    case Listerine.Channels.remove_courses(args) do
       [] -> Message.reply(message, "Didn't remove any channels")
       cl -> Message.reply(message, "Removed: #{Listerine.Helpers.unwords(cl)}")
     end

--- a/lib/Listerine/helpers.ex
+++ b/lib/Listerine/helpers.ex
@@ -4,7 +4,30 @@ defmodule Listerine.Helpers do
   def get_guild_icon_url(guild),
     do: "https://cdn.discordapp.com/icons/" <> guild.id <> "/" <> guild.icon <> ".png"
 
+  @doc """
+  Returns the intersection of the two sets
+  """
   def intersect(a, b), do: a -- (a -- b)
 
+  @doc """
+  Joins words with separating spaces.
+
+  ### Example:
+
+  `["The", "fox"]` becomes `"The fox"`
+  """
   def unwords(words), do: Enum.reduce(words, fn x, a -> a <> " " <> x end)
+
+  @doc """
+  Turns a string into a list of it's upcased words.
+
+  ### Example:
+  `"The quick brown fox jumps over the lazy dog"` becomes
+  `["THE", "QUICK", "BROWN", "FOX", "JUMPS", "OVER", "THE", "LAZY", "DOG"]`
+  """
+  def upcase_words(string) do
+    String.split(string, " ")
+    |> Enum.filter(fn x -> x != "" end)
+    |> Enum.map(&String.upcase/1)
+  end
 end


### PR DESCRIPTION
There is a lot going on here so I'm going to list the reason for (nearly) every change
#### Code
1. `add_role` and `rm_role`
    * The explicit recursion here caused `get_courses()` to execute multiple times, this being and IO action, I think it's best avoided. The merging of the maps was also repeated but this is less severe.
    * The result from `get_courses()` was also not checked, as this value can be `nil`.
    * To merge the maps, the keys were hard-coded, which means that if any of them returned `nil` the whole function would crash.
    * Making these funtions return a tuple is kinda pointless since it was always `{:ok, [wtv]}` so I removed that and only return the list
2. `study` and `unstudy`
    * The variable passed to these functions is never `[]` as the api doesn't call the functions if the user doesn't pass arguments.
3. `mkcourses`, `rmcourses`, `study` and `unstudy`
    * Moved the input handling to a function in Helpers `upcase_words` and used it in all 4 of these so this treatment is more consistent.

#### Docs
I also documented a most functions in the `Helpers` module along with `add_role` and `rm_role`