### PR TITLE
Rename function

### DIFF
--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -181,7 +181,7 @@ defmodule Listerine.Channels do
 
   Returns a list of added roles
   """
-  def add_role(message, courses) do
+  def add_roles(message, courses) do
     guild = message.channel.guild_id
     member = Guild.get_member(guild, message.author.id)
 

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -11,7 +11,7 @@ defmodule Listerine.Commands do
   command study(roles) do
     role_list = Listerine.Helpers.upcase_words(roles)
 
-    case Listerine.Channels.add_role(message, role_list) do
+    case Listerine.Channels.add_roles(message, role_list) do
       [] -> Message.reply(message, "No roles were added")
       cl -> Message.reply(message, "Studying: #{Listerine.Helpers.unwords(cl)}")
     end


### PR DESCRIPTION
Rename function `add_role` to a less deceptive name `add_roles`