### PR TITLE
Add channel anexos to the category

### DIFF
--- a/lib/Listerine/channels.ex
+++ b/lib/Listerine/channels.ex
@@ -103,10 +103,11 @@ defmodule Listerine.Channels do
 
     cat = Guild.create_channel(guild, %{name: course, type: 4, permission_overwrites: ow})
     ch1 = Guild.create_channel(guild, %{name: "duvidas", type: 0, parent_id: cat.id})
+    ch2 = Guild.create_channel(guild, %{name: "anexos", type: 0, parent_id: cat.id})
 
     Map.put(create_course_channels(guild, others), cat.name, %{
       "role" => role.id,
-      "channels" => [cat.id, ch1.id]
+      "channels" => [cat.id, ch1.id, ch2.id]
     })
   end
 

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -33,6 +33,16 @@ defmodule Listerine.Commands do
   command unstudy(roles) do
     role_list = Listerine.Helpers.upcase_words(roles)
 
+    role_list =
+      Enum.map(
+        role_list,
+        fn
+          <<year::binary-size(1), "ANO">> -> Listerine.Channels.get_roles_year(year)
+          x -> x
+        end
+      )
+      |> List.flatten()
+
     case Listerine.Channels.rm_role(message, role_list) do
       [] -> Message.reply(message, "No roles were removed")
       cl -> Message.reply(message, "Stoped studiyng #{Listerine.Helpers.unwords(cl)}")

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -12,7 +12,7 @@ defmodule Listerine.Commands do
   ]
 
   command study(roles) do
-    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.role_list_flatten()
+    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.roles_per_year()
 
     case Listerine.Channels.add_roles(message, role_list) do
       [] -> Message.reply(message, "No roles were added")
@@ -21,7 +21,7 @@ defmodule Listerine.Commands do
   end
 
   command unstudy(roles) do
-    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.role_list_flatten()
+    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.roles_per_year()
 
     case Listerine.Channels.rm_role(message, role_list) do
       [] -> Message.reply(message, "No roles were removed")

--- a/lib/Listerine/commands.ex
+++ b/lib/Listerine/commands.ex
@@ -12,17 +12,7 @@ defmodule Listerine.Commands do
   ]
 
   command study(roles) do
-    role_list = Listerine.Helpers.upcase_words(roles)
-
-    role_list =
-      Enum.map(
-        role_list,
-        fn
-          <<year::binary-size(1), "ANO">> -> Listerine.Channels.get_roles_year(year)
-          x -> x
-        end
-      )
-      |> List.flatten()
+    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.role_list_flatten()
 
     case Listerine.Channels.add_roles(message, role_list) do
       [] -> Message.reply(message, "No roles were added")
@@ -31,17 +21,7 @@ defmodule Listerine.Commands do
   end
 
   command unstudy(roles) do
-    role_list = Listerine.Helpers.upcase_words(roles)
-
-    role_list =
-      Enum.map(
-        role_list,
-        fn
-          <<year::binary-size(1), "ANO">> -> Listerine.Channels.get_roles_year(year)
-          x -> x
-        end
-      )
-      |> List.flatten()
+    role_list = Listerine.Helpers.upcase_words(roles) |> Listerine.Helpers.role_list_flatten()
 
     case Listerine.Channels.rm_role(message, role_list) do
       [] -> Message.reply(message, "No roles were removed")

--- a/lib/Listerine/helpers.ex
+++ b/lib/Listerine/helpers.ex
@@ -4,6 +4,17 @@ defmodule Listerine.Helpers do
   def get_guild_icon_url(guild),
     do: "https://cdn.discordapp.com/icons/" <> guild.id <> "/" <> guild.icon <> ".png"
 
+  def role_list_flatten(role_list) do
+    Enum.map(
+      role_list,
+      fn
+        <<year::binary-size(1), "ANO">> -> Listerine.Channels.get_roles_year(year)
+        x -> x
+      end
+    )
+    |> List.flatten()
+  end
+
   @doc """
   Returns the intersection of the two sets.
   Note: It's right associative.

--- a/lib/Listerine/helpers.ex
+++ b/lib/Listerine/helpers.ex
@@ -4,7 +4,7 @@ defmodule Listerine.Helpers do
   def get_guild_icon_url(guild),
     do: "https://cdn.discordapp.com/icons/" <> guild.id <> "/" <> guild.icon <> ".png"
 
-  def role_list_flatten(role_list) do
+  def roles_per_year(role_list) do
     Enum.map(
       role_list,
       fn


### PR DESCRIPTION
Add the channel anexos when a course is generated.
Also add respective id to the json

Note: also adds the ability to delet all roles in a year with the command `$unstudy 1ano`